### PR TITLE
Update readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ It has the ability to aggregate results from a log file, calculate metrics,
 compare results with reference values, monitor a remote machine with the tested application. 
 Additionally, it allows viewing all the results of performance tests as charts.
 
-Last version: https://teamcity.jetbrains.com/repository/download/TeamCityPluginsByJetBrains_JMeterPlugin_Build/.lastSuccessful/jmeter.zip
+Last version: https://teamcity.jetbrains.com/repository/download/TeamCityPluginsByJetBrains_JMeterPlugin_Build/.lastSuccessful/jmeter.zip?guest=1
 
 How it works
 ==============


### PR DESCRIPTION
In order to download the zip file, the user must either log in or qualify themselves as a guest. Passing the guest query argument to the url will help reduce confusion about this process and allow the user to more easily download the plugin.
